### PR TITLE
SQLServer Schema Modification should use NVARCHAR

### DIFF
--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -478,12 +478,12 @@ module Sequel
       
 
       # Specify unicode strings by default for Strings.
-      # If a size isn't present, Sequel assumes a size of 255.
-      # If the :fixed option is used, Sequel uses the char type.
-      # If the :text option is used, Sequel uses the :text type.
+      # If a size isn't present, assumes a size of 255.
+      # If the :fixed option is used, uses the nchar type.
+      # If the :text option is used, MSSQL prefers nvarchar(max) as text and ntext are depricated.
       def type_literal_generic_string(column)
         if column[:text]
-          :ntext
+          "nvarchar(max)"
         elsif column[:fixed]
           "nchar(#{column[:size]||default_string_column_size})"
         else

--- a/lib/sequel/adapters/shared/mssql.rb
+++ b/lib/sequel/adapters/shared/mssql.rb
@@ -476,6 +476,21 @@ module Sequel
         @mssql_unicode_strings = typecast_value_boolean(@opts.fetch(:mssql_unicode_strings, true))
       end
       
+
+      # Specify unicode strings by default for Strings.
+      # If a size isn't present, Sequel assumes a size of 255.
+      # If the :fixed option is used, Sequel uses the char type.
+      # If the :text option is used, Sequel uses the :text type.
+      def type_literal_generic_string(column)
+        if column[:text]
+          :ntext
+        elsif column[:fixed]
+          "nchar(#{column[:size]||default_string_column_size})"
+        else
+          "nvarchar(#{column[:size]||default_string_column_size})"
+        end
+      end
+
       # MSSQL has both datetime and timestamp classes, most people are going
       # to want datetime
       def type_literal_generic_datetime(column)


### PR DESCRIPTION
I'm starting this pull request into my own master so that I can work on collecting thoughts and issues to present back to Jeremy Evans.

By default, SQL Server's schema modifications interpret `String` columns as `VARCHAR` columns. Meanwhile, the default querying mode is to query with NVARCHAR `N'term'` strings. When left to defaults, performance can be severely impacted. At best, SQL Server needs to internally handle a conversion from a unicode filter string to the target column type. However, much worse and costly, *indexes are not able to be used*.

- [Original note in Sequel-Talk](https://groups.google.com/g/sequel-talk/c/1O3LPGmAirg/m/lnPxRtXjCAAJ)
- [Third party reference to the issue](https://www.sqlshack.com/query-performance-issues-on-varchar-data-type-using-an-n-prefix/)

I've put together a sample benchmark application [here](https://github.com/ttilberg/sequel-sqlserver-nvarchar-performance) that shows a difference of nearly 100X performance due to the inability to reference indexes. (Woah!)